### PR TITLE
.gitignore 에서 application.properties 삭제

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 
 
 # application.properties
-application.properties
 schema.sql
 
 ### Eclipse ###


### PR DESCRIPTION
h2 사용 / musql 사용하는 사람 구분하기 위해  .gitignore에 application.properties 추가
-> application.properties을 이미 커밋 & 푸시한 상태이기 때문에 추적이 되어 무의미해짐